### PR TITLE
fix(dss): name DSS/grid files by true storm rank, not enumeration index

### DIFF
--- a/src/actions/__init__.py
+++ b/src/actions/__init__.py
@@ -1,0 +1,47 @@
+"""Storm-cloud plugin actions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+def parse_storm_datetime(item: Any) -> datetime | None:
+    """Storm start datetime for a STAC item, or None if unparseable.
+
+    Older catalogs use a ``%Y-%m-%dT%H`` item id; newer ones use the por_rank as
+    the id and carry the datetime on ``item.datetime``.
+    """
+    try:
+        return datetime.strptime(item.id, "%Y-%m-%dT%H")
+    except (TypeError, ValueError):
+        # ValueError: id is a por_rank (e.g. "441"), not a datetime.
+        # TypeError: id is None. Both fall through to item.datetime.
+        return item.datetime if getattr(item, "datetime", None) else None
+
+
+def storm_rank(item: Any, fallback: int) -> int:
+    """Return a storm item's catalog rank (por_rank).
+
+    storm_search encodes por_rank as the item id (``item_id = f"{por_rank}"``),
+    so the true rank is ``int(item.id)``. get_all_items() is NOT rank-sorted, so
+    the enumeration index mislabels files (e.g. por_rank 441 named r003) and,
+    because names are the idempotency key, re-runs accumulate orphan duplicates.
+    Fall back to ``fallback`` only when the id is not a plain rank integer (e.g.
+    the ``%Y-%m-%dT%H`` id used when a storm is searched without a rank).
+    """
+    try:
+        return int(item.id)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def dss_filename(storm_start: datetime, rank: int, storm_duration: Any) -> str:
+    """Canonical DSS filename for a storm.
+
+    convert_to_dss (producer) and create_grid_file (which must find that same
+    file) both derive names here, so the two stay in lockstep — any drift would
+    silently mis-pair storms with DSS files.
+    """
+    date_str = storm_start.strftime("%Y%m%d")
+    return f"{date_str}_{storm_duration}hr_st1_r{rank:03d}.dss"

--- a/src/actions/convert_to_dss.py
+++ b/src/actions/convert_to_dss.py
@@ -9,18 +9,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
+from actions import dss_filename, parse_storm_datetime, storm_rank
+
 log = logging.getLogger(__name__)
 
 # If every storm fails, that's an error. Allow up to this fraction to fail.
 MAX_FAILURE_RATIO = float(os.environ.get("DSS_MAX_FAILURE_RATIO", "0.5"))
 DSS_WORKERS = int(os.environ.get("DSS_WORKERS", "0"))  # 0 = auto (cpu_count)
-
-
-def _parse_storm_datetime(item: Any) -> Optional[datetime]:
-    try:
-        return datetime.strptime(item.id, "%Y-%m-%dT%H")
-    except ValueError:
-        return item.datetime if item.datetime else None
 
 
 def _convert_single_storm(
@@ -80,16 +75,14 @@ def convert_to_dss(ctx: dict[str, Any], action: Any) -> None:
     work: list[tuple[str, str, str]] = []  # (item_id, output_path, storm_start_iso)
     skipped: list[str] = []
     for idx, item in enumerate(items, 1):
-        storm_start = _parse_storm_datetime(item)
+        storm_start = parse_storm_datetime(item)
         if storm_start is None:
             log.warning("Skipping item %s: could not parse datetime", item.id)
             skipped.append(item.id)
             continue
 
-        date_str = storm_start.strftime("%Y%m%d")
-        rank_padded = str(idx).zfill(3)
-        dss_filename = f"{date_str}_{storm_duration}hr_st1_r{rank_padded}.dss"
-        output_path = str(dss_dir / dss_filename)
+        filename = dss_filename(storm_start, storm_rank(item, idx), storm_duration)
+        output_path = str(dss_dir / filename)
 
         # Idempotency: skip if DSS file already exists
         if Path(output_path).exists():

--- a/src/actions/create_grid_file.py
+++ b/src/actions/create_grid_file.py
@@ -20,6 +20,8 @@ from typing import Any, Iterable
 
 from pyproj import Transformer
 
+from actions import dss_filename, parse_storm_datetime, storm_rank
+
 log = logging.getLogger(__name__)
 
 INDENT = "     "  # 5 spaces, matches HMS GridManagerWriter.LARGE_INDENT
@@ -49,14 +51,6 @@ _ALBERS_CRS_WKT = (
     'CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["US survey foot",0.304800609601219,ID["EPSG",9003]]],'
     'AXIS["(N)",north,ORDER[2],LENGTHUNIT["US survey foot",0.304800609601219,ID["EPSG",9003]]]]'
 )
-
-
-def _parse_storm_datetime(item: Any) -> datetime | None:
-    """Replicates convert_to_dss._parse_storm_datetime to pair items with DSS files."""
-    try:
-        return datetime.strptime(item.id, "%Y-%m-%dT%H")
-    except ValueError:
-        return item.datetime if getattr(item, "datetime", None) else None
 
 
 def _centroid_lonlat(item: Any) -> tuple[float, float] | None:
@@ -221,19 +215,17 @@ def create_grid_file(ctx: dict[str, Any], action: Any) -> None:
     failed: list[str] = []
 
     for idx, item in enumerate(items, start=1):
-        storm_start = _parse_storm_datetime(item)
+        storm_start = parse_storm_datetime(item)
         if storm_start is None:
             log.warning("Skipping item %s: unparseable datetime", item.id)
             failed.append(item.id)
             continue
 
-        date_str = storm_start.strftime("%Y%m%d")
-        rank_padded = str(idx).zfill(3)
-        dss_filename = f"{date_str}_{storm_duration}hr_st1_r{rank_padded}.dss"
-        dss_path = dss_dir / dss_filename
+        filename = dss_filename(storm_start, storm_rank(item, idx), storm_duration)
+        dss_path = dss_dir / filename
 
         if not dss_path.exists():
-            log.warning("Skipping %s: %s not found", item.id, dss_filename)
+            log.warning("Skipping %s: %s not found", item.id, filename)
             failed.append(item.id)
             continue
 
@@ -255,8 +247,8 @@ def create_grid_file(ctx: dict[str, Any], action: Any) -> None:
                 "No centroid for %s — emitting grid without Storm Center", item.id
             )
 
-        grid_base = dss_filename[:-4]  # drop ".dss"
-        rel_dss = f"data/{dss_filename}"
+        grid_base = filename[:-4]  # drop ".dss"
+        rel_dss = f"data/{filename}"
 
         if precip_pn is not None:
             entries.append(

--- a/test/test_storm_rank.py
+++ b/test/test_storm_rank.py
@@ -1,0 +1,92 @@
+"""Unit tests for storm rank / DSS filename derivation.
+
+Regression guard: DSS files and grid blocks must be named by the storm's true
+catalog rank (por_rank, encoded as the STAC item id), not the enumeration
+position of get_all_items() (which is not rank-sorted). Mislabeling both
+misnames files and, because the name is the idempotency key, makes re-runs
+accumulate orphan duplicates.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC))
+
+from actions import dss_filename, parse_storm_datetime, storm_rank  # noqa: E402
+
+
+class _Item:
+    def __init__(self, item_id, dt=None):
+        self.id = item_id
+        self.datetime = dt
+
+
+def test_uses_item_id_not_enumeration_index():
+    # The 3rd item returned by get_all_items() can be por_rank 441.
+    assert storm_rank(_Item("441"), fallback=3) == 441
+
+
+def test_falls_back_for_non_numeric_id():
+    # storm_search uses a %Y-%m-%dT%H id when searched without a rank.
+    assert storm_rank(_Item("1982-06-07T06"), fallback=7) == 7
+
+
+def test_falls_back_for_none_id():
+    assert storm_rank(_Item(None), fallback=12) == 12
+
+
+def test_filename_encodes_true_rank():
+    # por_rank 441 -> r441, never r003 (its enumeration position).
+    rank = storm_rank(_Item("441"), fallback=3)
+    assert dss_filename(datetime(1982, 6, 7, 6), rank, 72) == "19820607_72hr_st1_r441.dss"
+
+
+def test_parse_datetime_from_legacy_id():
+    assert parse_storm_datetime(_Item("1982-06-07T06")) == datetime(1982, 6, 7, 6)
+
+
+def test_parse_datetime_from_item_datetime_for_rank_id():
+    dt = datetime(1982, 6, 7, 6)
+    # Rank-keyed id ("441") isn't a datetime; fall back to item.datetime.
+    assert parse_storm_datetime(_Item("441", dt=dt)) == dt
+
+
+def test_parse_datetime_none_id_does_not_raise():
+    # A None id makes strptime raise TypeError, not ValueError; parse must
+    # tolerate it and fall through to item.datetime rather than crash the loop.
+    dt = datetime(1982, 6, 7, 6, tzinfo=timezone.utc)
+    assert parse_storm_datetime(_Item(None, dt=dt)) == dt
+    assert parse_storm_datetime(_Item(None)) is None
+
+
+def test_producers_derive_identical_filenames():
+    """Lockstep invariant: convert_to_dss (writes the DSS) and create_grid_file
+    (must locate that same DSS) have to agree on the filename byte-for-byte.
+    Both now derive it via the single ``dss_filename`` helper, so re-run the
+    exact derivation each loop performs and assert one shared result. The
+    source guard below keeps them from re-inlining a divergent format string.
+    """
+    item = _Item("441", dt=datetime(1982, 6, 7, 6))
+    idx, duration = 3, 72
+
+    def derive(it, i):
+        start = parse_storm_datetime(it)
+        return dss_filename(start, storm_rank(it, i), duration)
+
+    # Simulate both producer loops over the same item at the same position.
+    convert_name = derive(item, idx)
+    grid_name = derive(item, idx)
+    assert convert_name == grid_name == "19820607_72hr_st1_r441.dss"
+
+
+def test_neither_producer_reinlines_the_format():
+    """Drift guard: the ``…hr_st1_r…`` format must live only in dss_filename.
+    If a producer re-inlines it, the two can diverge without any test noticing.
+    """
+    for name in ("convert_to_dss.py", "create_grid_file.py"):
+        source = (SRC / "actions" / name).read_text()
+        assert "hr_st1_r" not in source, f"{name} re-inlines the DSS format; call dss_filename()"


### PR DESCRIPTION
storm_search encodes a storm's por_rank as its STAC item id (item_id = f"{por_rank}"), but convert_to_dss and create_grid_file named files by the get_all_items() enumeration index instead. get_all_items() is not rank-sorted, so files were mislabeled (e.g. por_rank 441 written as r003) and, because the filename is the idempotency key, re-runs accumulated orphan duplicates rather than overwriting.

Derive the rank from item.id (falling back to the enumeration index only for the legacy %Y-%m-%dT%H id used when a storm is searched without a rank), and consolidate the shared item->name logic into src/actions:

  - storm_rank(item, fallback): int(item.id), else fallback.
  - parse_storm_datetime(item): legacy-id datetime, else item.datetime; tolerates a None id (strptime raises TypeError, not ValueError).
  - dss_filename(start, rank, duration): the single filename format used by both the producer (convert_to_dss) and the consumer that must locate that same file (create_grid_file), so the two cannot drift.

Tests cover rank selection, datetime parsing (legacy id / rank id / None id), the producer/consumer lockstep invariant, and a source guard that neither producer re-inlines the filename format.