### PR TITLE
Adopt stormhub 0.5.0 fork: AORC mirror, performance, robustness

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/stormhub"]
 	path = lib/stormhub
-	url = https://github.com/Dewberry/stormhub.git
-	branch = v0.4.0
+	url = https://github.com/nghiemv/stormhub.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ Storm parameters are in `attributes`. All values are strings (CC SDK convention)
 | `input_path` | yes | | S3 path to watershed/transposition geometries |
 | `output_path` | yes | | S3 path for results |
 
+## AORC Data Source
+
+By default the plugin reads AORC from the anonymous **NOAA public bucket** — no
+credentials needed. To read from a faster **private/regional S3 mirror**, add an
+optional `AORC` credentials profile to the manifest (see `manifest.example.json`);
+`src/aorc_env.py` maps it onto the `AORC_S3_*` env vars stormhub reads and derives
+`s3://<bucket>` (set `AORC_S3_PREFIX` if the yearly `*.zarr` stores are nested).
+Omit the profile to use NOAA public. For local testing, fill in the commented
+`AORC_AWS_*` block in `test/local.env`.
+
 ## Dev Tasks
 
 ```bash
@@ -81,5 +91,5 @@ thread-cap env vars in the Dockerfile.
 
 ## Known Limitations
 
-- **stormhub v0.5.0**: Workers hang during storm collection. Pinned to v0.4.0.
+- **stormhub v0.5.0 worker hang (resolved):** stock v0.5.0 workers hang during storm collection — forked pool workers deadlock on their first S3 read (fork doesn't duplicate fsspec's async event-loop thread). The `lib/stormhub` fork fixes this with a `spawn` process context, which is what lets this plugin run on the 0.5.0 line.
 - **stormhub thread fan-out**: `num_workers` only caps the *process* pool. Each worker still appears to fan out internally (likely via dask's threaded scheduler in the AORC loader and/or BLAS threads), so peak RSS scales with the container's visible vCPU count even at `num_workers=1`. **Workaround:** in addition to setting `num_workers=1` (payload attribute or `CC_NUM_WORKERS=1`), cap the container's CPU allocation so intra-worker threads can't fan out past what the memory budget tolerates. For a 15 GB cap, `cpus: "4"` (Docker Compose `deploy.resources.limits` or `--cpus 4` on `docker run`) has held under the limit in our runs. Tighten further if OOMs reappear.

--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@
 # Pins stormhub's transitive dependencies and direct deps to known-good versions.
 # Regenerate: python run.py freeze
 
-# --- stormhub pinned deps (from lib/stormhub/pyproject.toml v0.4.0) ---
+# --- stormhub pinned deps (from lib/stormhub/pyproject.toml, nghiemv fork @ main / v0.5.0) ---
 fiona==1.9.6
 geopandas==1.0.1
 matplotlib==3.9.0
@@ -18,9 +18,12 @@ dask==2025.1.0
 numcodecs==0.13.1
 scipy==1.15.2
 dataretrieval==1.0.11
+stac-geoparquet==0.7.0
 
 # --- direct plugin deps (from requirements.txt) ---
-hecdss==0.1.25
+# hecdss bumped 0.1.25 -> 0.1.29: stormhub 0.5.0 pins hecdss==0.1.29, which would
+# otherwise conflict with the old 0.1.25 constraint at install time.
+hecdss==0.1.29
 dataclasses-json==0.5.14
 numpy==1.26.4
 pandas==2.2.3

--- a/manifest.example.json
+++ b/manifest.example.json
@@ -14,6 +14,14 @@
       "aws_secret_access_key": "",
       "aws_default_region": "us-east-1",
       "aws_s3_bucket": ""
+    },
+    "AORC": {
+      "_comment": "OPTIONAL. Provide to read AORC from a private/regional S3 mirror (faster); omit for the anonymous NOAA public bucket. src/aorc_env.py maps these AORC_AWS_* creds to the AORC_S3_* names stormhub reads and derives s3://<aws_s3_bucket> (set AORC_S3_PREFIX in environment if the year zarrs live under a bucket prefix).",
+      "aws_access_key_id": "",
+      "aws_secret_access_key": "",
+      "aws_default_region": "us-east-1",
+      "aws_endpoint": "",
+      "aws_s3_bucket": ""
     }
   }
 }

--- a/run.py
+++ b/run.py
@@ -100,11 +100,13 @@ def cmd_run(payload_file: str) -> None:
     container_path = "/inputs/" + payload_file.replace("\\", "/").split("test/", 1)[-1]
 
     print(f"Running: {payload_file}\n")
-    run_cmd(
-        ["docker", "compose", "run", "--rm", "seed"],
-        env={"PAYLOAD_FILE": container_path},
-    )
-    run_cmd(["docker", "compose", "run", "--rm", "storm-cloud-plugin"])
+    # PAYLOAD_FILE must be set on BOTH runs. The plugin service depends_on the
+    # `seed` service, and because `seed` is `run --rm` (removed after it exits),
+    # `run storm-cloud-plugin` re-runs it — re-seeding with the default payload
+    # and silently overwriting the custom one unless PAYLOAD_FILE is set here too.
+    seed_env = {"PAYLOAD_FILE": container_path}
+    run_cmd(["docker", "compose", "run", "--rm", "seed"], env=seed_env)
+    run_cmd(["docker", "compose", "run", "--rm", "storm-cloud-plugin"], env=seed_env)
 
 
 TASK_COMMANDS = {

--- a/src/actions/__init__.py
+++ b/src/actions/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 
@@ -11,13 +11,22 @@ def parse_storm_datetime(item: Any) -> datetime | None:
 
     Older catalogs use a ``%Y-%m-%dT%H`` item id; newer ones use the por_rank as
     the id and carry the datetime on ``item.datetime``.
+
+    Always returns a tz-naive UTC datetime. pystac's ``item.datetime`` is
+    tz-aware (UTC), but AORC's zarr ``time`` coordinate is tz-naive; slicing the
+    dataset with a tz-aware bound raises "Cannot compare tz-naive and tz-aware
+    datetime-like objects" in convert-to-dss. Normalizing here keeps the return
+    type consistent with the ``strptime`` branch and with the AORC data.
     """
     try:
         return datetime.strptime(item.id, "%Y-%m-%dT%H")
     except (TypeError, ValueError):
         # ValueError: id is a por_rank (e.g. "441"), not a datetime.
         # TypeError: id is None. Both fall through to item.datetime.
-        return item.datetime if getattr(item, "datetime", None) else None
+        dt = item.datetime if getattr(item, "datetime", None) else None
+        if dt is not None and dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
 
 
 def storm_rank(item: Any, fallback: int) -> int:

--- a/src/actions/convert_to_dss.py
+++ b/src/actions/convert_to_dss.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
@@ -16,6 +17,9 @@ log = logging.getLogger(__name__)
 # If every storm fails, that's an error. Allow up to this fraction to fail.
 MAX_FAILURE_RATIO = float(os.environ.get("DSS_MAX_FAILURE_RATIO", "0.5"))
 DSS_WORKERS = int(os.environ.get("DSS_WORKERS", "0"))  # 0 = auto (cpu_count)
+# HEC SHG output grid resolution for the DSS grids; AORC → SHG 4 km is standard.
+# stormhub 0.5.0's noaa_zarr_to_dss requires this explicitly (no default upstream).
+DSS_OUTPUT_RESOLUTION_KM = int(os.environ.get("DSS_OUTPUT_RESOLUTION_KM", "4"))
 
 
 def _convert_single_storm(
@@ -42,6 +46,7 @@ def _convert_single_storm(
                 NOAADataVariable.APCP: storm_duration,
                 NOAADataVariable.TMP: storm_duration,
             },
+            output_resolution_km=DSS_OUTPUT_RESOLUTION_KM,
         )
         return None
     except Exception as e:
@@ -105,7 +110,12 @@ def convert_to_dss(ctx: dict[str, Any], action: Any) -> None:
         )
         log.info("Running %d conversions with %d workers", len(work), workers)
 
-        with ProcessPoolExecutor(max_workers=workers) as pool:
+        # Explicit spawn context: the worker's first act is an fsspec/s3fs AORC
+        # read, which deadlocks in a *forked* worker (fork doesn't duplicate
+        # fsspec's async event-loop thread). Don't rely on the global default.
+        with ProcessPoolExecutor(
+            max_workers=workers, mp_context=multiprocessing.get_context("spawn")
+        ) as pool:
             futures = {
                 pool.submit(
                     _convert_single_storm,

--- a/src/aorc_env.py
+++ b/src/aorc_env.py
@@ -1,0 +1,53 @@
+"""Bridge Cloud Compute AORC credentials to the env vars stormhub reads.
+
+stormhub selects the AORC source from ``AORC_S3_*`` env vars (see
+``stormhub.met.zarr_to_dss.aorc_storage_options``): when ``AORC_S3_KEY`` is set
+it reads an authenticated S3 mirror at ``AORC_S3_ENDPOINT`` / ``AORC_S3_BASE_URL``
+(with ``AORC_S3_SECRET`` and optional ``AORC_S3_REGION``); otherwise it reads the
+anonymous NOAA public bucket.
+
+Cloud Compute injects credential *profiles* as ``<PROFILE>_AWS_*`` env vars
+(that is how the ``FFRD`` store creds reach the container), so an ``AORC``
+profile arrives as ``AORC_AWS_ACCESS_KEY_ID`` etc. This module maps those to the
+``AORC_S3_*`` names and derives ``AORC_S3_BASE_URL`` from the profile bucket
+(optionally under ``AORC_S3_PREFIX``), so the mirror can be configured with a CC
+credentials profile and the keys never sit in plaintext ``environment``.
+
+``apply()`` runs on import — BEFORE stormhub is imported, because
+``AORC_S3_BASE_URL`` is read at stormhub import time. It is idempotent and never
+overrides values already set (so a direct ``AORC_S3_*`` environment still works),
+and it is a no-op when no AORC credentials are present (anonymous NOAA public).
+"""
+
+import os
+
+# Cloud Compute ``<profile>_AWS_*`` name -> the ``AORC_S3_*`` name stormhub reads.
+_CRED_MAP = {
+    "AORC_AWS_ACCESS_KEY_ID": "AORC_S3_KEY",
+    "AORC_AWS_SECRET_ACCESS_KEY": "AORC_S3_SECRET",
+    "AORC_AWS_ENDPOINT": "AORC_S3_ENDPOINT",
+    "AORC_AWS_DEFAULT_REGION": "AORC_S3_REGION",
+}
+
+
+def apply(env: dict | None = None) -> None:
+    """Populate ``AORC_S3_*`` from CC ``AORC_AWS_*`` creds; existing values win."""
+    env = os.environ if env is None else env
+
+    for src, dst in _CRED_MAP.items():
+        value = env.get(src)
+        if value and not env.get(dst):
+            env[dst] = value
+
+    # Derive the bucket URL from the profile bucket when not set directly. If the
+    # year zarrs live under a bucket prefix, set AORC_S3_PREFIX; otherwise the
+    # bucket root is used. AORC_S3_BASE_URL, if set, always wins.
+    if not env.get("AORC_S3_BASE_URL"):
+        bucket = env.get("AORC_AWS_S3_BUCKET")
+        if bucket:
+            prefix = env.get("AORC_S3_PREFIX", "").strip("/")
+            base = f"s3://{bucket.strip('/')}"
+            env["AORC_S3_BASE_URL"] = f"{base}/{prefix}" if prefix else base
+
+
+apply()

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -5,6 +5,11 @@ Initializes the PluginManager, validates the payload, and dispatches actions.
 
 from __future__ import annotations
 
+# Map any Cloud Compute AORC mirror credentials onto the AORC_S3_* env vars
+# stormhub reads. Import first: it runs on import and AORC_S3_BASE_URL must be
+# set before stormhub is imported below.
+import aorc_env  # noqa: F401
+
 import logging
 import logging.config
 import multiprocessing
@@ -61,10 +66,15 @@ def _configure_logging() -> None:
 _configure_logging()
 log = logging.getLogger(__name__)
 
-try:
-    multiprocessing.set_start_method("spawn")
-except RuntimeError:
-    pass
+# Force spawn as the multiprocessing default. The action imports above touch
+# multiprocessing during import, which fixes the start method to "fork" before
+# this line runs — so a plain set_start_method("spawn") raises "context has
+# already been set" and (when swallowed) leaves the default at fork. Any
+# default-context ProcessPoolExecutor then FORKs, and forked workers deadlock on
+# their first fsspec/s3fs read because fork doesn't duplicate fsspec's async
+# event-loop thread. force=True makes spawn the effective default; ValueError
+# (spawn unavailable) would be a genuine platform problem, so let it surface.
+multiprocessing.set_start_method("spawn", force=True)
 
 
 class ExitCode(IntEnum):

--- a/test/local.env
+++ b/test/local.env
@@ -31,3 +31,16 @@ FFRD_AWS_SECRET_ACCESS_KEY=ffrdsecretkey
 # --- Paths for MinIO seeding (must match payloads in test/examples/) ---
 FFRD_STORE_ROOT=model-library/ffrd-trinity
 FFRD_INPUT_PATH=conformance/storm-catalog
+
+# --- AORC source (optional) ---
+# Unset -> read AORC from the anonymous NOAA public bucket (works, slower).
+# Fill in the AORC profile below -> read from a private/regional S3 mirror.
+# src/aorc_env.py maps these AORC_AWS_* vars to the AORC_S3_* names stormhub
+# reads and derives s3://<bucket> (add AORC_S3_PREFIX if the year zarrs are
+# nested under a prefix). Uncomment and set to your mirror:
+# AORC_AWS_ACCESS_KEY_ID=
+# AORC_AWS_SECRET_ACCESS_KEY=
+# AORC_AWS_ENDPOINT=
+# AORC_AWS_DEFAULT_REGION=us-east-1
+# AORC_AWS_S3_BUCKET=
+# AORC_S3_PREFIX=

--- a/test/test_aorc_env.py
+++ b/test/test_aorc_env.py
@@ -1,0 +1,51 @@
+"""Tests for the Cloud Compute -> stormhub AORC credential bridge."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from aorc_env import apply  # noqa: E402
+
+
+def test_maps_cc_profile_to_stormhub_names():
+    env = {
+        "AORC_AWS_ACCESS_KEY_ID": "AK",
+        "AORC_AWS_SECRET_ACCESS_KEY": "SK",
+        "AORC_AWS_ENDPOINT": "https://s3.example.com",
+        "AORC_AWS_DEFAULT_REGION": "us-east-1",
+        "AORC_AWS_S3_BUCKET": "my-aorc-mirror",
+    }
+    apply(env)
+    assert env["AORC_S3_KEY"] == "AK"
+    assert env["AORC_S3_SECRET"] == "SK"
+    assert env["AORC_S3_ENDPOINT"] == "https://s3.example.com"
+    assert env["AORC_S3_REGION"] == "us-east-1"
+    assert env["AORC_S3_BASE_URL"] == "s3://my-aorc-mirror"  # no prefix -> bucket root
+
+
+def test_noop_without_aorc_creds():
+    env = {"FFRD_AWS_ACCESS_KEY_ID": "x"}
+    apply(env)
+    assert "AORC_S3_KEY" not in env
+    assert "AORC_S3_BASE_URL" not in env
+
+
+def test_existing_aorc_s3_values_win():
+    env = {"AORC_AWS_ACCESS_KEY_ID": "AK", "AORC_S3_KEY": "explicit"}
+    apply(env)
+    assert env["AORC_S3_KEY"] == "explicit"
+
+
+def test_explicit_base_url_beats_derived():
+    env = {"AORC_AWS_S3_BUCKET": "my-aorc-mirror", "AORC_S3_BASE_URL": "s3://other/x"}
+    apply(env)
+    assert env["AORC_S3_BASE_URL"] == "s3://other/x"
+
+
+def test_prefix_is_appended_when_set():
+    env = {"AORC_AWS_S3_BUCKET": "my-aorc-mirror", "AORC_S3_PREFIX": "cache/conus"}
+    apply(env)
+    assert env["AORC_S3_BASE_URL"] == "s3://my-aorc-mirror/cache/conus"

--- a/test/test_storm_rank.py
+++ b/test/test_storm_rank.py
@@ -10,7 +10,7 @@ accumulate orphan duplicates.
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 SRC = Path(__file__).resolve().parent.parent / "src"
@@ -58,9 +58,22 @@ def test_parse_datetime_from_item_datetime_for_rank_id():
 def test_parse_datetime_none_id_does_not_raise():
     # A None id makes strptime raise TypeError, not ValueError; parse must
     # tolerate it and fall through to item.datetime rather than crash the loop.
+    # tz-aware item.datetime is normalized to tz-naive UTC (see below).
     dt = datetime(1982, 6, 7, 6, tzinfo=timezone.utc)
-    assert parse_storm_datetime(_Item(None, dt=dt)) == dt
+    result = parse_storm_datetime(_Item(None, dt=dt))
+    assert result == datetime(1982, 6, 7, 6)
+    assert result.tzinfo is None
     assert parse_storm_datetime(_Item(None)) is None
+
+
+def test_parse_datetime_returns_tz_naive_utc():
+    # pystac item.datetime is tz-aware; AORC's zarr time coord is tz-naive, so a
+    # tz-aware bound raises "Cannot compare tz-naive and tz-aware ..." when
+    # slicing in convert-to-dss. parse_storm_datetime must return tz-naive UTC.
+    dt = datetime(1982, 6, 7, 6, tzinfo=timezone(timedelta(hours=5)))  # 06:00+05:00
+    result = parse_storm_datetime(_Item("441", dt=dt))
+    assert result == datetime(1982, 6, 7, 1)  # 01:00 UTC, naive
+    assert result.tzinfo is None
 
 
 def test_producers_derive_identical_filenames():


### PR DESCRIPTION
Points `lib/stormhub` at the maintained fork (Dewberry **0.5.0** + robustness/perf/AORC-source/DSS hardening) and adapts the plugin to run on it. Adds an optional AORC S3 mirror, a local dev-harness fix, and small README notes.

## Why
The plugin was pinned to stormhub 0.4.0 because stock 0.5.0 **hangs during storm collection** — forked pool workers deadlock on their first S3 read (fork doesn't duplicate fsspec's async event-loop thread). The fork fixes this with a `spawn` process context, unblocking the 0.5.0 line (plus ~100× faster transposition, a cached zarr opener, and correctness fixes).

## Changes (5 commits)
- **deps(stormhub)** — pin `lib/stormhub` to the fork's `main`; `constraints.txt`: `hecdss` 0.1.25→0.1.29 (0.5.0 pins ==0.1.29) + `stac-geoparquet==0.7.0`.
- **fix: DSS path for 0.5.0** — pass `output_resolution_km` (now required on `noaa_zarr_to_dss`); run the convert pool under an explicit spawn context; `parse_storm_datetime` returns tz-naive UTC (0.5.0 items are por-rank–keyed, so it falls back to pystac's tz-aware `item.datetime`, which clashed with AORC's tz-naive time coord).
- **fix(plugin)** — force `spawn` as the multiprocessing default (a plain `set_start_method("spawn")` was silently ineffective), and add `src/aorc_env.py` to bridge an optional Cloud Compute `AORC` credentials profile onto the `AORC_S3_*` vars stormhub reads.
- **fix(run.py)** — local `run.py <payload>` no longer has its custom payload overwritten by the plugin service's re-seed.
- **docs** — an "AORC Data Source" section + refreshed v0.5.0 note.

## AORC source
Default is the **anonymous NOAA public bucket** (no creds). To use a faster **private/regional S3 mirror**, add an optional `AORC` credentials profile to the manifest (see `manifest.example.json`); `src/aorc_env.py` maps it to `AORC_S3_*` and derives `s3://<bucket>` (+ optional `AORC_S3_PREFIX`). Keys stay in CC credentials, not plaintext `environment`. Config is fully generic — no deployment-specific values in the repo.

## Testing
- **33 unit tests** pass.
- **End-to-end across all reference projects** (Trinity, Kanawha 48/120hr, Duwamish, Christmas_Valley, Whitehorse, UpperSheyenne, indian-creek, etc.): all complete cleanly, DSS/grid files use the true por-rank (verified against out-of-order ranks), and `catalog.grid` stays in lockstep with the DSS files.
- **Deep output validation**: DSS record counts (`duration × 2`), data ranges/units (precip ≥ 0 mm; temperature in °C, not Kelvin), SHG-4K albers grids, hourly-cumulative precip vs. instantaneous temperature pathnames.
- **Mirror path** verified end-to-end (reads from the mirror, ~5× faster than NOAA public, identical outputs).

## Note
Temperature grids are written in the unit stormhub is configured for (currently **°C**) — confirm that matches your HEC-HMS models.