### PR TITLE
fix(convert-to-dss): size worker pool from cgroup budget, not host CPUs

### DIFF
--- a/src/actions/convert_to_dss.py
+++ b/src/actions/convert_to_dss.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from actions import dss_filename, parse_storm_datetime, storm_rank
+from worker_sizing import resolve_num_workers
 
 log = logging.getLogger(__name__)
 
@@ -105,9 +106,17 @@ def convert_to_dss(ctx: dict[str, Any], action: Any) -> None:
     failed: list[str] = list(skipped)
 
     if work:
-        workers = (
-            DSS_WORKERS if DSS_WORKERS > 0 else min(len(work), os.cpu_count() or 1)
-        )
+        # Size the pool from the cgroup memory budget, not os.cpu_count(): inside
+        # a container cpu_count() reports the *host* CPU count, so the old
+        # fallback spawned 8 rio.reproject workers on an 8-core node and blew the
+        # 12000Mi cgroup in seconds (OOMKill, exit 137). resolve_num_workers is
+        # the same memory-aware sizing process-storms already trusts, and it
+        # honors the num_workers payload attr / CC_NUM_WORKERS env. DSS_WORKERS
+        # remains an explicit override for a fatter host.
+        if DSS_WORKERS > 0:
+            workers = DSS_WORKERS
+        else:
+            workers = min(len(work), resolve_num_workers(attrs))
         log.info("Running %d conversions with %d workers", len(work), workers)
 
         # Explicit spawn context: the worker's first act is an fsspec/s3fs AORC


### PR DESCRIPTION
`convert-to-dss` fell back to `min(len(work), os.cpu_count())` when `DSS_WORKERS`
was unset. In a container `os.cpu_count()` reports the node's CPU count (8), so 8
`rio.reproject` workers blew the 12000Mi cgroup and the pod OOMKilled (exit 137),
discarding an 18-hour `process-storms` catalog.

Route the auto path through `worker_sizing.resolve_num_workers` — the same
cgroup-derived cap `process-storms` already uses (honors `num_workers` /
`CC_NUM_WORKERS`). `DSS_WORKERS` stays as an explicit override.

Low risk: unchanged when `DSS_WORKERS` is set; 8 workers OOM, so the cgroup count
is the feasible max. `resolve_num_workers` is covered by `test/test_worker_sizing.py`.
