### PR TITLE
feat(resume): durable local_root + resume the scan instead of restarting it

### DIFF
--- a/src/actions/process_storms.py
+++ b/src/actions/process_storms.py
@@ -9,11 +9,39 @@ from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 from typing import Any
 
-from stormhub.met.storm_catalog import StormCatalog, new_catalog, new_collection
+from stormhub.met.storm_catalog import (
+    StormCatalog,
+    new_catalog,
+    new_collection,
+    resume_collection,
+)
 
 from worker_sizing import resolve_num_workers
+import scan_state
 
 log = logging.getLogger(__name__)
+
+
+def _can_resume_scan(
+    catalog_dir: Path, storm_duration: int, storm_params: dict
+) -> bool:
+    """True iff a trustworthy partial scan exists to resume from.
+
+    Requires all of: matching param fingerprint (guards against resuming onto a
+    catalog built for a different request), a saved catalog.json, and a
+    ``storm-stats.csv`` that holds at least one well-formed row after repair.
+    ``specific_dates`` runs can't be resumed by missing-date diffing, so they
+    always rebuild.
+    """
+    if storm_params["specific_dates"]:
+        return False
+    if not scan_state.params_match(catalog_dir, storm_params):
+        return False
+    catalog_json = catalog_dir / "catalog.json"
+    stats_csv = catalog_dir / f"{storm_duration}hr-events" / "storm-stats.csv"
+    if not (catalog_json.exists() and stats_csv.exists()):
+        return False
+    return scan_state.repair_partial_csv(stats_csv)
 
 
 def _try_reload_collection(
@@ -45,6 +73,75 @@ def _try_reload_collection(
         return None
 
 
+def _oom_runtime_error(storm_params: dict) -> RuntimeError:
+    return RuntimeError(
+        f"Storm processing pool died with num_workers="
+        f"{storm_params['num_workers']} (likely OOM). Lower via "
+        "'num_workers' payload attribute or CC_NUM_WORKERS env."
+    )
+
+
+def _build_collection(
+    *,
+    resume: bool,
+    catalog_dir: Path,
+    catalog_json: Path,
+    config_path: Path,
+    catalog_id: str,
+    local_root: Path,
+    attrs: Any,
+    storm_params: dict,
+) -> Any:
+    """Build the storm collection, resuming the partial scan when safe.
+
+    A resume that fails for any *non-OOM* reason is not fatal: the partial state
+    is quarantined and the scan is rebuilt from scratch exactly once, so a bug on
+    the resume path can never strand an otherwise-runnable job. OOM
+    (``BrokenProcessPool``) is re-raised with actionable guidance — retrying fresh
+    would just OOM again.
+    """
+
+    def _fresh() -> Any:
+        catalog = new_catalog(
+            catalog_id,
+            str(config_path),
+            local_directory=str(local_root),
+            catalog_description=attrs["catalog_description"],
+        )
+        # Record the fingerprint before the multi-hour scan so a mid-scan death is
+        # resumable on the next attempt.
+        scan_state.write_fingerprint(catalog_dir, storm_params)
+        return new_collection(catalog, **storm_params)
+
+    try:
+        if resume:
+            log.info("Resuming scan — searching only the missing dates")
+            resume_params = {
+                k: v for k, v in storm_params.items() if k != "specific_dates"
+            }
+            collection = resume_collection(str(catalog_json), **resume_params)
+        else:
+            log.info("Running a fresh storm search")
+            collection = _fresh()
+    except BrokenProcessPool as e:
+        raise _oom_runtime_error(storm_params) from e
+    except Exception as e:
+        if not resume:
+            raise
+        log.warning(
+            "Resume failed (%s) — quarantining partial state and rebuilding fresh", e
+        )
+        scan_state.quarantine(catalog_dir)
+        try:
+            collection = _fresh()
+        except BrokenProcessPool as e2:
+            raise _oom_runtime_error(storm_params) from e2
+
+    if collection is None:
+        raise RuntimeError("no storms found matching criteria")
+    return collection
+
+
 def process_storms(ctx: dict[str, Any], action: Any) -> None:
     payload = ctx["payload"]
     local_root: Path = ctx["local_root"]
@@ -74,29 +171,47 @@ def process_storms(ctx: dict[str, Any], action: Any) -> None:
         else [],
     }
 
-    # Try to resume from a previous run's saved catalog/collection
-    collection = _try_reload_collection(
-        str(local_root), catalog_id, storm_params["storm_duration"]
-    )
+    # Resume ladder. Every rung relies on local_root being durable across pod
+    # restarts (see the CC_LOCAL_ROOT mount in plugin.py); on ephemeral storage
+    # only the fresh path is ever taken. Each rung is guarded so resume is
+    # *trustworthy*, not merely possible — see scan_state for the guards.
+    storm_duration = storm_params["storm_duration"]
+    catalog_dir = Path(local_root) / catalog_id
+    catalog_json = catalog_dir / "catalog.json"
 
-    if collection is None:
-        catalog = new_catalog(
-            catalog_id,
-            str(config_path),
-            local_directory=str(local_root),
-            catalog_description=attrs["catalog_description"],
-        )
+    # Guard 1 (param drift): state left by a run with different parameters must
+    # never be reused — resuming onto it would silently build a wrong catalog.
+    # Quarantine it (keep for debugging) and start clean.
+    saved = scan_state.saved_fingerprint(catalog_dir)
+    if saved is not None and saved != scan_state.fingerprint(storm_params):
+        log.warning("Scan parameters changed since the last run — not reusing stale state")
+        scan_state.quarantine(catalog_dir)
 
-        try:
-            collection = new_collection(catalog, **storm_params)
-        except BrokenProcessPool as e:
-            raise RuntimeError(
-                f"Storm processing pool died with num_workers="
-                f"{storm_params['num_workers']} (likely OOM). Lower via "
-                "'num_workers' payload attribute or CC_NUM_WORKERS env."
-            ) from e
+    # Rung 1 (reload): trust a complete catalog only when the completion sentinel
+    # is present AND the fingerprint matches. A bare catalog.json may be a
+    # half-built collection from a pod that died during item creation.
+    collection = None
+    if scan_state.params_match(catalog_dir, storm_params) and scan_state.is_marked_complete(
+        catalog_dir
+    ):
+        collection = _try_reload_collection(str(local_root), catalog_id, storm_duration)
         if collection is None:
-            raise RuntimeError("no storms found matching criteria")
+            log.warning("Completion marker present but catalog would not reload — rebuilding")
+
+    # Rungs 2 & 3 (resume the partial scan, else fresh search).
+    if collection is None:
+        resume = _can_resume_scan(catalog_dir, storm_duration, storm_params)
+        collection = _build_collection(
+            resume=resume,
+            catalog_dir=catalog_dir,
+            catalog_json=catalog_json,
+            config_path=config_path,
+            catalog_id=catalog_id,
+            local_root=local_root,
+            attrs=attrs,
+            storm_params=storm_params,
+        )
+        scan_state.mark_complete(catalog_dir)
 
     log.info("Catalog and collection ready")
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -176,10 +176,58 @@ def validate_payload(payload: Any) -> None:
         raise ValueError(f"Missing required input path keys: {missing_keys}")
 
 
+def _preflight_local_root(local_root: Path, explicit: bool) -> None:
+    """Fail fast if the resume root isn't a usable durable mount.
+
+    A silently-unwritable or object-FUSE CC_LOCAL_ROOT would defeat resume (or,
+    on FUSE, make stormhub's per-date fsync pathological). Verify writability up
+    front and warn on a FUSE mount rather than discovering it hours into a scan.
+    """
+    probe = local_root / ".write-probe"
+    try:
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+    except OSError as e:
+        raise RuntimeError(f"local_root {local_root} is not writable: {e}") from e
+
+    if not explicit:
+        return  # default ephemeral "Local" — nothing to warn about
+
+    try:
+        resolved = str(local_root.resolve())
+        best_fstype = ""
+        best_len = -1
+        for line in Path("/proc/mounts").read_text(encoding="utf-8").splitlines():
+            fields = line.split()
+            if len(fields) < 3:
+                continue
+            mountpoint, fstype = fields[1], fields[2]
+            if (resolved == mountpoint or resolved.startswith(mountpoint.rstrip("/") + "/")) and len(
+                mountpoint
+            ) > best_len:
+                best_len, best_fstype = len(mountpoint), fstype
+        if best_fstype.startswith("fuse"):
+            log.warning(
+                "CC_LOCAL_ROOT (%s) is on a FUSE mount (%s). stormhub fsyncs the "
+                "scan CSV per date; use a block PVC, not object-storage FUSE.",
+                resolved,
+                best_fstype,
+            )
+    except OSError:
+        pass  # /proc/mounts unavailable — best-effort check only
+
+
 def run_actions(pm: PluginManager, payload: Any) -> None:
     """Dispatch each action in the payload by name."""
-    local_root = Path("Local")
+    # local_root holds every resumable artifact — the STAC catalog, the flushed
+    # storm-stats.csv scan progress, and the DSS grids. Point CC_LOCAL_ROOT at a
+    # durable mount (e.g. the pod's /model PVC) so these survive a pod restart and
+    # each action's on-disk idempotency can resume instead of repeating work.
+    # Unset -> "Local" (ephemeral overlay), preserving the previous behavior.
+    _local_base = os.environ.get("CC_LOCAL_ROOT")
+    local_root = (Path(_local_base) / "Local") if _local_base else Path("Local")
     local_root.mkdir(parents=True, exist_ok=True)
+    _preflight_local_root(local_root, explicit=bool(_local_base))
 
     interrupted = False
     succeeded = False
@@ -192,12 +240,13 @@ def run_actions(pm: PluginManager, payload: Any) -> None:
     signal.signal(signal.SIGTERM, handle_signal)
     signal.signal(signal.SIGINT, handle_signal)
 
-    # Track completed actions for checkpoint/resume
-    checkpoint_file = local_root / ".checkpoint"
-    completed_actions: set[str] = set()
-    if checkpoint_file.exists():
-        completed_actions = set(checkpoint_file.read_text().splitlines())
-        log.info("Resuming from checkpoint — already completed: %s", completed_actions)
+    # Resume is a property of the actions, not a separate ledger: every action is
+    # idempotent against local_root (process-storms reloads/resumes the catalog,
+    # convert-to-dss skips existing .dss, etc.), so a resumed run simply re-runs
+    # from the top and each action short-circuits its own completed work. This
+    # replaces the old .checkpoint skip-list, which — because it skipped
+    # process-storms outright — left ctx["collection"] unset and broke every
+    # downstream action on resume.
 
     # Shared context passed to all actions
     ctx: dict[str, Any] = {
@@ -222,15 +271,6 @@ def run_actions(pm: PluginManager, payload: Any) -> None:
                 )
                 raise ValueError(f"Unknown action: {action.name}")
 
-            if action.name in completed_actions:
-                log.info(
-                    "[%d/%d] Skipping action (already completed): %s",
-                    i + 1,
-                    len(payload.actions),
-                    action.name,
-                )
-                continue
-
             log.info(
                 "[%d/%d] Running action: %s", i + 1, len(payload.actions), action.name
             )
@@ -241,12 +281,6 @@ def run_actions(pm: PluginManager, payload: Any) -> None:
                 "Action %s completed in %.1fs",
                 action.name,
                 elapsed,
-            )
-
-            # Checkpoint after each successful action
-            completed_actions.add(action.name)
-            checkpoint_file.write_text(
-                "\n".join(sorted(completed_actions)), encoding="utf-8"
             )
 
         succeeded = True

--- a/src/scan_state.py
+++ b/src/scan_state.py
@@ -1,0 +1,162 @@
+"""Durable, *validated* resume state for the process-storms scan.
+
+process-storms can run for many hours; a pod can die at any point. These helpers
+make resume **safe** rather than merely possible. They refuse to trust on-disk
+state that does not match the current request or that is corrupt/partial, and
+they *quarantine* (never delete) anything they reject, so a run always makes
+forward progress and nothing is silently destroyed.
+
+Three independent guards:
+
+* **Param fingerprint** — the scan is only reusable if the parameters that decide
+  *which* dates are searched and *how* events are ranked are unchanged. A changed
+  request must never resume onto a catalog built for different parameters (that
+  would silently produce a wrong result).
+* **Completion sentinel** — a catalog is only trusted as "complete" (reload, skip
+  the search) once the whole stage finished. A pod that died between "scan done"
+  and "catalog saved" left a partial collection; without the sentinel we resume
+  instead of shipping a truncated top-N.
+* **CSV repair** — a pod killed mid-write can leave a torn/ragged final row in the
+  flushed scan CSV. We keep every well-formed row and drop the rest, so resume
+  never miscomputes the missing-date set and never crashes on a partial line.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Files written under the catalog dir (local_root/<catalog_id>/) to track state.
+PARAMS_FILE = ".scan-params.json"  # fingerprint of the scan request
+COMPLETE_FILE = ".scan-complete"  # sentinel: the scan + catalog fully finished
+
+# The parameters that determine which dates are scanned and how events are ranked.
+# If any of these differ from a prior run, that run's partial/complete scan is not
+# reusable for this request.
+_FINGERPRINT_KEYS = (
+    "start_date",
+    "end_date",
+    "storm_duration",
+    "min_precip_threshold",
+    "top_n_events",
+    "check_every_n_hours",
+    "specific_dates",
+)
+
+# storm_date column format stormhub writes (see storm_search_results_to_csv_line).
+_CSV_DATE_FMT = "%Y-%m-%dT%H"
+
+
+def fingerprint(storm_params: dict) -> dict:
+    """The subset of storm_params that must match for on-disk scan state to be reused."""
+    fp: dict = {}
+    for key in _FINGERPRINT_KEYS:
+        value = storm_params.get(key)
+        if isinstance(value, list):
+            value = sorted(str(v) for v in value)  # order-insensitive
+        fp[key] = value
+    return fp
+
+
+def saved_fingerprint(catalog_dir: Path) -> dict | None:
+    """Read the fingerprint recorded by a prior run, or None if absent/unreadable."""
+    try:
+        return json.loads((catalog_dir / PARAMS_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def write_fingerprint(catalog_dir: Path, storm_params: dict) -> None:
+    """Record the current request's fingerprint before the expensive scan starts."""
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    (catalog_dir / PARAMS_FILE).write_text(
+        json.dumps(fingerprint(storm_params), sort_keys=True, indent=2),
+        encoding="utf-8",
+    )
+
+
+def params_match(catalog_dir: Path, storm_params: dict) -> bool:
+    """True iff a prior fingerprint exists and equals the current request's."""
+    saved = saved_fingerprint(catalog_dir)
+    return saved is not None and saved == fingerprint(storm_params)
+
+
+def mark_complete(catalog_dir: Path) -> None:
+    """Record that process-storms fully finished — the catalog is safe to reload."""
+    (catalog_dir / COMPLETE_FILE).write_text("ok\n", encoding="utf-8")
+
+
+def is_marked_complete(catalog_dir: Path) -> bool:
+    return (catalog_dir / COMPLETE_FILE).exists()
+
+
+def quarantine(path: Path) -> Path | None:
+    """Move `path` aside to a sibling `<name>.quarantine-N`. Never deletes.
+
+    Returns the new location, or None if `path` did not exist.
+    """
+    if not path.exists():
+        return None
+    for n in range(1, 1000):
+        dest = path.with_name(f"{path.name}.quarantine-{n}")
+        if not dest.exists():
+            shutil.move(str(path), str(dest))
+            log.warning("Quarantined stale/corrupt scan state: %s -> %s", path, dest)
+            return dest
+    raise RuntimeError(f"Too many quarantine directories beside {path}")
+
+
+def repair_partial_csv(csv_path: Path) -> bool:
+    """Validate and, if needed, repair a partial scan CSV in place.
+
+    A pod killed mid-write can leave a torn or ragged final row. Keep every
+    well-formed data row (correct column count + parseable storm_date), drop the
+    rest, and rewrite atomically. Returns True iff at least one good data row
+    remains — i.e. the CSV is usable to resume from.
+    """
+    try:
+        original = csv_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    lines = original.splitlines()
+    if len(lines) < 2:  # header only, or empty
+        return False
+
+    header = lines[0]
+    ncol = header.count(",") + 1
+    kept = [header]
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        parts = line.split(",")
+        if len(parts) != ncol:
+            continue  # torn / ragged row
+        try:
+            datetime.strptime(parts[0], _CSV_DATE_FMT)
+        except ValueError:
+            continue  # unparseable date (partial line)
+        kept.append(line)
+
+    if len(kept) < 2:
+        return False
+
+    repaired = "\n".join(kept) + "\n"
+    if repaired != original:
+        dropped = (len(lines) - 1) - (len(kept) - 1)
+        tmp = csv_path.with_name(csv_path.name + ".repair-tmp")
+        tmp.write_text(repaired, encoding="utf-8")
+        os.replace(str(tmp), str(csv_path))  # atomic
+        log.warning(
+            "Repaired partial scan CSV %s (dropped %d torn/blank row(s), kept %d)",
+            csv_path,
+            dropped,
+            len(kept) - 1,
+        )
+    return True

--- a/test/test_process_storms_flow.py
+++ b/test/test_process_storms_flow.py
@@ -1,0 +1,208 @@
+"""Integration tests for the process_storms resume decision routing.
+
+stormhub is stubbed so we can assert *which* path runs (reload / resume / fresh)
+under pod-death scenarios, without a real AORC scan.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(_SRC))
+sys.path.insert(0, str(_SRC / "actions"))
+
+# --- stub stormhub.met.storm_catalog before importing process_storms -------
+
+calls = {"new_catalog": 0, "new_collection": 0, "resume_collection": 0}
+state = {"reload_items": None, "resume_fails": False}
+
+
+class _FakeCollection:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def get_all_items(self):
+        return list(self._items)
+
+
+class _FakeSPM:
+    def storm_collection_id(self, duration):
+        return f"{duration}hr-events"
+
+
+class _FakeCatalog:
+    def __init__(self, collection=None):
+        self.spm = _FakeSPM()
+        self._collection = collection
+
+    def get_child(self, _cid):
+        return self._collection
+
+
+def _new_catalog(catalog_id, _config, local_directory=None, catalog_description=None):
+    calls["new_catalog"] += 1
+    cat_dir = Path(local_directory) / catalog_id
+    cat_dir.mkdir(parents=True, exist_ok=True)
+    (cat_dir / "catalog.json").write_text("{}", encoding="utf-8")
+    return _FakeCatalog()
+
+
+def _new_collection(_catalog, **_kw):
+    calls["new_collection"] += 1
+    return _FakeCollection(["item-1"])
+
+
+def _resume_collection(_catalog_json, **_kw):
+    calls["resume_collection"] += 1
+    if state["resume_fails"]:
+        raise RuntimeError("simulated resume failure")
+    return _FakeCollection(["item-1"])
+
+
+class _FakeStormCatalog:
+    @staticmethod
+    def from_file(_path):
+        items = state["reload_items"]
+        return _FakeCatalog(_FakeCollection(items) if items else None)
+
+
+_stub = types.ModuleType("stormhub.met.storm_catalog")
+_stub.StormCatalog = _FakeStormCatalog
+_stub.new_catalog = _new_catalog
+_stub.new_collection = _new_collection
+_stub.resume_collection = _resume_collection
+sys.modules.setdefault("stormhub", types.ModuleType("stormhub"))
+sys.modules.setdefault("stormhub.met", types.ModuleType("stormhub.met"))
+sys.modules["stormhub.met.storm_catalog"] = _stub
+
+import process_storms  # noqa: E402
+import scan_state  # noqa: E402
+
+_HEADER = "storm_date,min,mean,max,x,y"
+_ROW = "1979-02-01T00,0.0,1.2,9.9,-100.0,40.0"
+
+_ATTRS = {
+    "catalog_id": "cat",
+    "catalog_description": "desc",
+    "output_path": "s3://bucket/out",
+    "start_date": "1979-02-01",
+    "end_date": "1979-03-01",
+    "storm_duration": "72",
+    "top_n_events": "10",
+    "check_every_n_hours": "24",
+    "min_precip_threshold": "0.0",
+}
+
+
+class _Payload:
+    def __init__(self, attrs):
+        self.attributes = dict(attrs)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    calls.update(new_catalog=0, new_collection=0, resume_collection=0)
+    state.update(reload_items=None, resume_fails=False)
+
+
+def _run(tmp_path, attrs=None):
+    ctx = {
+        "payload": _Payload(attrs or _ATTRS),
+        "local_root": tmp_path,
+        "config_path": tmp_path / "config.json",
+    }
+    process_storms.process_storms(ctx, action=None)
+    return ctx
+
+
+def _seed_partial_scan(tmp_path, attrs=None):
+    """Simulate a pod that died mid-scan: fingerprint + partial CSV, no sentinel."""
+    cat_dir = tmp_path / "cat"
+    (cat_dir / "72hr-events").mkdir(parents=True)
+    (cat_dir / "catalog.json").write_text("{}", encoding="utf-8")
+    (cat_dir / "72hr-events" / "storm-stats.csv").write_text(
+        _HEADER + "\n" + _ROW + "\n", encoding="utf-8"
+    )
+    # Fingerprint matching the run we'll launch.
+    params = _fingerprint_params(attrs or _ATTRS)
+    scan_state.write_fingerprint(cat_dir, params)
+
+
+def _fingerprint_params(attrs):
+    return {
+        "start_date": attrs["start_date"],
+        "end_date": attrs["end_date"],
+        "storm_duration": int(attrs["storm_duration"]),
+        "min_precip_threshold": float(attrs["min_precip_threshold"]),
+        "top_n_events": int(attrs["top_n_events"]),
+        "check_every_n_hours": int(attrs["check_every_n_hours"]),
+        "specific_dates": [],
+    }
+
+
+def test_fresh_when_nothing_on_disk(tmp_path):
+    ctx = _run(tmp_path)
+    assert calls["new_collection"] == 1 and calls["resume_collection"] == 0
+    cat_dir = tmp_path / "cat"
+    assert scan_state.is_marked_complete(cat_dir)  # sentinel written
+    assert (cat_dir / scan_state.PARAMS_FILE).exists()  # fingerprint written
+    assert ctx["collection"] is not None
+
+
+def test_reload_when_complete_and_matching(tmp_path):
+    _run(tmp_path)  # complete a run (writes sentinel + fingerprint)
+    calls.update(new_catalog=0, new_collection=0, resume_collection=0)
+    state["reload_items"] = ["item-1"]  # reload succeeds
+
+    _run(tmp_path)
+    assert calls["new_collection"] == 0 and calls["resume_collection"] == 0  # reloaded
+
+
+def test_param_drift_quarantines_and_rebuilds(tmp_path):
+    _run(tmp_path)  # complete with top_n_events=10
+    calls.update(new_catalog=0, new_collection=0, resume_collection=0)
+
+    drifted = dict(_ATTRS, top_n_events="5")
+    _run(tmp_path, drifted)
+
+    assert (tmp_path / "cat.quarantine-1").exists()  # old state preserved, not deleted
+    assert calls["new_collection"] == 1 and calls["resume_collection"] == 0  # fresh
+    # fingerprint now reflects the new request
+    assert scan_state.params_match(tmp_path / "cat", _fingerprint_params(drifted))
+
+
+def test_resume_when_partial_scan_present(tmp_path):
+    _seed_partial_scan(tmp_path)
+    _run(tmp_path)
+    assert calls["resume_collection"] == 1 and calls["new_collection"] == 0
+    assert scan_state.is_marked_complete(tmp_path / "cat")
+
+
+def test_resume_failure_falls_back_to_fresh(tmp_path):
+    _seed_partial_scan(tmp_path)
+    state["resume_fails"] = True
+
+    ctx = _run(tmp_path)
+    assert calls["resume_collection"] == 1  # attempted
+    assert calls["new_collection"] == 1  # then rebuilt fresh
+    assert (tmp_path / "cat.quarantine-1").exists()  # partial quarantined
+    assert ctx["collection"] is not None  # job still completes
+
+
+def test_incomplete_collection_not_reloaded(tmp_path):
+    # catalog.json + fingerprint present but NO sentinel and NO partial CSV:
+    # a pod that died mid item-creation. Must not reload a truncated collection.
+    cat_dir = tmp_path / "cat"
+    cat_dir.mkdir()
+    (cat_dir / "catalog.json").write_text("{}", encoding="utf-8")
+    scan_state.write_fingerprint(cat_dir, _fingerprint_params(_ATTRS))
+    state["reload_items"] = ["item-1"]  # even if reload *could* return items
+
+    _run(tmp_path)
+    # No sentinel -> reload not trusted; rebuilt fresh instead.
+    assert calls["new_collection"] == 1

--- a/test/test_scan_state.py
+++ b/test/test_scan_state.py
@@ -1,0 +1,140 @@
+"""Unit tests for scan_state — the durable/validated resume guards."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import scan_state  # noqa: E402
+
+_HEADER = "storm_date,min,mean,max,x,y"
+_ROW1 = "1979-02-01T00,0.0,1.2,9.9,-100.0,40.0"
+_ROW2 = "1979-02-02T00,0.1,1.3,9.8,-100.0,40.0"
+
+
+def _params(**over):
+    base = {
+        "start_date": "1979-02-01",
+        "end_date": "1979-03-01",
+        "storm_duration": 72,
+        "min_precip_threshold": 0.0,
+        "top_n_events": 10,
+        "check_every_n_hours": 24,
+        "num_workers": 3,  # deliberately NOT part of the fingerprint
+        "specific_dates": [],
+    }
+    base.update(over)
+    return base
+
+
+# --- fingerprint -----------------------------------------------------------
+
+
+def test_fingerprint_ignores_non_scan_params():
+    # num_workers must not affect reuse — it's an execution knob, not a scan input.
+    assert scan_state.fingerprint(_params(num_workers=3)) == scan_state.fingerprint(
+        _params(num_workers=8)
+    )
+
+
+def test_fingerprint_changes_with_scan_params():
+    assert scan_state.fingerprint(_params(storm_duration=72)) != scan_state.fingerprint(
+        _params(storm_duration=24)
+    )
+
+
+def test_fingerprint_specific_dates_order_insensitive():
+    a = scan_state.fingerprint(_params(specific_dates=["2001-01-01", "2002-02-02"]))
+    b = scan_state.fingerprint(_params(specific_dates=["2002-02-02", "2001-01-01"]))
+    assert a == b
+
+
+def test_params_match_roundtrip(tmp_path):
+    scan_state.write_fingerprint(tmp_path, _params())
+    assert scan_state.params_match(tmp_path, _params())
+    assert scan_state.params_match(tmp_path, _params(num_workers=99))  # knob ignored
+    assert not scan_state.params_match(tmp_path, _params(top_n_events=5))
+
+
+def test_params_match_false_when_no_fingerprint(tmp_path):
+    assert not scan_state.params_match(tmp_path, _params())
+
+
+# --- completion sentinel ---------------------------------------------------
+
+
+def test_completion_sentinel(tmp_path):
+    assert not scan_state.is_marked_complete(tmp_path)
+    scan_state.mark_complete(tmp_path)
+    assert scan_state.is_marked_complete(tmp_path)
+
+
+# --- quarantine ------------------------------------------------------------
+
+
+def test_quarantine_moves_not_deletes(tmp_path):
+    d = tmp_path / "cat"
+    d.mkdir()
+    (d / "keep.txt").write_text("data")
+    dest = scan_state.quarantine(d)
+    assert dest is not None
+    assert not d.exists()
+    assert (dest / "keep.txt").read_text() == "data"  # nothing destroyed
+
+
+def test_quarantine_missing_is_noop(tmp_path):
+    assert scan_state.quarantine(tmp_path / "nope") is None
+
+
+def test_quarantine_multiple_no_collision(tmp_path):
+    for _ in range(3):
+        (tmp_path / "cat").mkdir()
+        assert scan_state.quarantine(tmp_path / "cat") is not None
+    quarantined = sorted(p.name for p in tmp_path.iterdir())
+    assert quarantined == ["cat.quarantine-1", "cat.quarantine-2", "cat.quarantine-3"]
+
+
+# --- CSV repair / validation ----------------------------------------------
+
+
+def _csv(tmp_path, body):
+    p = tmp_path / "storm-stats.csv"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_repair_accepts_clean_csv_untouched(tmp_path):
+    p = _csv(tmp_path, "\n".join([_HEADER, _ROW1, _ROW2]) + "\n")
+    before = p.read_text()
+    assert scan_state.repair_partial_csv(p) is True
+    assert p.read_text() == before  # no rewrite when already clean
+
+
+def test_repair_drops_torn_final_line(tmp_path):
+    # Pod killed mid-write: last row missing columns.
+    p = _csv(tmp_path, "\n".join([_HEADER, _ROW1, "1979-02-02T00,0.1,1.3"]) )
+    assert scan_state.repair_partial_csv(p) is True
+    lines = p.read_text().splitlines()
+    assert lines == [_HEADER, _ROW1]  # torn row dropped, good row kept
+
+
+def test_repair_drops_unparseable_date(tmp_path):
+    p = _csv(tmp_path, "\n".join([_HEADER, _ROW1, "1979-02-0,0,0,0,0,0"]))
+    assert scan_state.repair_partial_csv(p) is True
+    assert p.read_text().splitlines() == [_HEADER, _ROW1]
+
+
+def test_repair_header_only_is_unusable(tmp_path):
+    p = _csv(tmp_path, _HEADER + "\n")
+    assert scan_state.repair_partial_csv(p) is False
+
+
+def test_repair_all_rows_torn_is_unusable(tmp_path):
+    p = _csv(tmp_path, "\n".join([_HEADER, "garbage", "also,bad"]))
+    assert scan_state.repair_partial_csv(p) is False
+
+
+def test_repair_missing_file_is_unusable(tmp_path):
+    assert scan_state.repair_partial_csv(tmp_path / "nope.csv") is False


### PR DESCRIPTION
A pod OOMKill discarded the whole run: `local_root` was `Path("Local")` on the
ephemeral overlay, so the catalog, the flushed `storm-stats.csv` scan progress, and
the DSS grids died with the pod. The `.checkpoint` skip-list also skipped
`process-storms` on resume, leaving `ctx["collection"]` unset and crashing downstream.

Changes:
- `local_root` honors `CC_LOCAL_ROOT` (point at the `/model` PVC); unset keeps the
  `Local` default.
- `process-storms` resume ladder: reload complete catalog → `resume_collection` over
  only missing dates → fresh search. A mid-scan OOM resumes where it died.
- Remove the `.checkpoint` skip-list. Actions are idempotent against `local_root`, so
  a resumed run re-runs from the top; `process-storms` always runs, so
  `ctx["collection"]` is always repopulated.

**Deploy pairing (required on-cluster):** set `CC_LOCAL_ROOT` to the durable `/model`
PVC and add an Argo `retryStrategy`. The mount must be block, not object-FUSE —
`multi_processor` fsyncs the CSV per date.

Happy path unchanged; resume adds seconds to save hours. New
`test/test_process_storms_resume.py` covers the partial-scan detector.
